### PR TITLE
Add documentation-driven tracking system and Origin Plan

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,52 @@
+# vbuilder Plan
+
+AI-maintained MEV block builder, forked from [flashbots/rbuilder](https://github.com/flashbots/rbuilder).
+
+## Status
+
+| Phase | Title                | Status  | Plan                                                  |
+| ----- | -------------------- | ------- | ----------------------------------------------------- |
+| 1     | Foundation           | pending | [000 - Origin Plan](docs/plans/000-origin-plan.md#phase-1---foundation) |
+| 2     | CI/CD Upgrade        | pending | [000 - Origin Plan](docs/plans/000-origin-plan.md#phase-2---cicd-upgrade) |
+| 3     | Bot Deployment       | pending | [000 - Origin Plan](docs/plans/000-origin-plan.md#phase-3---bot-deployment) |
+| 4     | Testing Harness      | pending | [000 - Origin Plan](docs/plans/000-origin-plan.md#phase-4---testing-harness) |
+| 5     | Self-Improvement     | pending | [000 - Origin Plan](docs/plans/000-origin-plan.md#phase-5---self-improvement) |
+
+## Quick Links
+
+- [Plans Index](docs/plans/README.md)
+- [Session Logs](docs/sessions/README.md)
+- Agent Instructions: TBD (Phase 1 deliverable: `CLAUDE.md`)
+- [Upstream: flashbots/rbuilder](https://github.com/flashbots/rbuilder)
+
+## Current Priorities
+
+1. Create `CLAUDE.md` with build commands, crate test table, and safety rules
+2. Set up `.ai/` directory with architecture, testing, and safety docs
+3. Add `.claude/commands/` for agent workflows
+4. Upgrade CI workflows for claude-code-action
+
+## Decision Framework
+
+When making implementation decisions, prefer:
+
+- **Safety first** - Never compromise relay submission guards, blocklist checks, or key management
+- **Upstream compatibility** - Minimize divergence from flashbots/rbuilder
+- **AI-friendly** - Optimize for agent comprehension (explicit over implicit, tables over prose)
+- **Incremental** - Each PR should be independently reviewable and revertable
+
+## Repository Structure
+
+```
+vbuilder/
+├── PLAN.md                  # This file - project dashboard
+├── CLAUDE.md                # Agent instructions (TBD)
+├── docs/
+│   ├── plans/               # Implementation plans
+│   └── sessions/            # Agent session logs
+├── .ai/                     # Agent context docs (TBD)
+├── .claude/commands/        # Custom slash commands (TBD)
+├── crates/                  # Rust workspace crates
+├── scripts/                 # Build and test scripts
+└── .github/workflows/       # CI/CD workflows
+```

--- a/docs/plans/000-origin-plan.md
+++ b/docs/plans/000-origin-plan.md
@@ -1,0 +1,152 @@
+# 000 - Origin Plan
+
+**Status:** active
+**Author:** halcyon
+**Created:** 2026-02-20
+
+## Summary
+
+Transform vbuilder (a fork of flashbots/rbuilder) into an AI-maintained MEV block builder. This plan defines the full roadmap from establishing agent infrastructure through autonomous issue resolution, organized in five incremental phases.
+
+## Motivation
+
+rbuilder is a complex, performance-critical Rust codebase. Manual development is slow and context-heavy. By equipping AI agents with proper guardrails, testing harnesses, and CI workflows, we can:
+
+- Accelerate development velocity on a large Rust codebase
+- Maintain testing discipline through automated compiler and test loops
+- Enable autonomous issue resolution with appropriate safety boundaries
+- Keep upstream compatibility with flashbots/rbuilder
+
+## Phase 1 - Foundation
+
+Establish the documentation and tooling that agents need to work safely in this repo.
+
+### CLAUDE.md
+
+Root-level agent instructions file containing:
+
+- **Build commands**: `cargo build`, `cargo clippy`, `cargo test` invocations with correct feature flags
+- **Crate-specific test lookup table**: Maps each crate to its test command and expected behavior so agents know how to validate changes in any part of the repo
+- **Safety rules**: Hard constraints agents must follow (never submit to mainnet relays, never disable blocklist checks, never modify bidding without review, etc.)
+- **Repository structure overview**: Crate map and dependency relationships
+
+### `.ai/` Directory
+
+- `architecture.md` - High-level architecture doc covering the block building pipeline, order flow, and crate responsibilities
+- `testing.md` - Testing strategy, how to run different test tiers, what needs playground vs unit tests
+- `safety.md` - Expanded safety rules: relay submission guards, blocklist enforcement, bidding constraints, key management
+
+### `.claude/commands/`
+
+Custom slash commands for common agent workflows:
+
+- `test` - Run the appropriate test suite for the current change
+- `lint` - Run clippy with project-specific configuration
+- `new-plan` - Create a new plan file from template
+- `session-log` - Create a session log entry from template
+
+## Phase 2 - CI/CD Upgrade
+
+Upgrade GitHub Actions workflows for AI-agent integration.
+
+### Claude Code Action
+
+- Upgrade `claude.yaml` to use `claude-code-action@v1`
+- Enable write permissions for issue-assigned triggers (agent picks up labeled issues)
+- Configure appropriate model and token limits
+
+### Security Review Workflow
+
+- Add a dedicated security review workflow for PRs touching safety-critical paths
+- Paths: relay submission, bidding logic, blocklist enforcement, key/signing code
+
+### Branch Protection
+
+- Require PR reviews for `develop` and `main`
+- Require CI to pass before merge
+- Block force pushes
+
+## Phase 3 - Bot Deployment
+
+Deploy the AI agent as an autonomous contributor.
+
+### Issue-Driven Workflow
+
+1. Issue is created and labeled (e.g., `claude`, `agent-safe`)
+2. Agent is assigned (manually or via automation)
+3. Agent creates a branch from `develop`
+4. Agent implements the change, running compiler loop and tests
+5. Agent opens a PR with description, test results, and session log
+6. Human reviews and merges
+
+### Guardrails
+
+- **Max diff size**: Limit PR size to prevent runaway changes
+- **Required labels**: Only work on issues with approved labels
+- **Safety-critical path protection**: Changes to relay, bidding, blocklist, or signing code require human review regardless of label
+- **No direct pushes**: All changes go through PRs
+
+## Phase 4 - Testing Harness
+
+Build the automated testing infrastructure that makes agent changes trustworthy.
+
+### Compiler Loop
+
+Standard agent workflow for any code change:
+
+1. `cargo check` - Fast compilation check
+2. `cargo clippy -- -D warnings` - Lint with warnings-as-errors
+3. `cargo test` - Run relevant test suite
+4. Iterate until all three pass
+
+### Builder Playground Integration
+
+- `scripts/playground-check.sh` - Script to run builder-playground integration tests
+- Integrate with builder-playground-action for CI
+- Smoke test: build a block with test orders, verify correctness
+
+### New Integration Test Scenarios
+
+- **Ordering correctness**: Verify transaction ordering respects gas price and bundle constraints
+- **Bidding logic**: Test bid calculation and submission under various conditions
+- **Cancellation handling**: Verify bundle and transaction cancellation propagates correctly
+
+## Phase 5 - Self-Improvement
+
+Enable the system to improve its own processes over time.
+
+### Session Logging
+
+- Agents write session logs after each work session (see [session log format](../sessions/README.md))
+- Logs capture what worked, what didn't, and what to do next
+- Enables continuity across sessions and agents
+
+### Documentation Evolution
+
+- Agents update `.ai/` docs when they discover outdated information
+- CLAUDE.md test lookup table is kept current as crates change
+- Plans are updated as phases complete
+
+### Upstream Sync Strategy
+
+- Regular sync with `flashbots/rbuilder` upstream
+- Track divergence in a dedicated doc
+- Prefer upstream changes unless vbuilder has intentional divergence
+
+## Open Questions
+
+These need decisions before or during implementation:
+
+1. **Bot identity**: Should we use a dedicated bot account, or use `@claude` mentions on a shared account? A dedicated account provides cleaner audit trails.
+2. **Mergify vs manual merge**: Should we use Mergify for auto-merging agent PRs that pass CI and review, or keep merging manual?
+3. **Upstream sync frequency**: How often should we sync with flashbots/rbuilder? Weekly? Per-release? On-demand?
+4. **Integration test cost**: Builder-playground tests may need 32-core runners. What's the acceptable CI cost per PR?
+5. **Scope of autonomous changes**: Should agents be allowed to refactor without an issue? What about dependency updates?
+
+## References
+
+- [vibehouse](https://github.com/dapplion/vibehouse) - Documentation-driven AI development pattern
+- [claude-code-action](https://github.com/anthropics/claude-code-action) - GitHub Action for Claude Code
+- [builder-playground](https://github.com/flashbots/builder-playground) - Integration test environment
+- [builder-playground-action](https://github.com/flashbots/builder-playground-action) - CI action for playground tests
+- [flashbots/rbuilder](https://github.com/flashbots/rbuilder) - Upstream repository

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,0 +1,31 @@
+# Plans
+
+This directory contains implementation plans for vbuilder development.
+
+## Format
+
+Each plan is a Markdown file named `NNN-short-title.md` where `NNN` is a 3-digit zero-padded sequence number. Plans are numbered in creation order starting from `000`.
+
+### Required Sections
+
+Every plan should include a frontmatter block and the following sections:
+
+- **Status** (`draft` | `active` | `completed` | `abandoned`), **Author**, **Created** date
+- **Summary**: One-paragraph description of what this plan covers
+- **Motivation**: Why this work is needed
+- **Phases / Steps**: Concrete implementation steps
+- **Open Questions**: Unresolved decisions (remove or move to a decisions section as they are resolved)
+- **References**: Links to relevant issues, PRs, external docs
+
+### Creating a Plan
+
+1. Find the next available number: `ls docs/plans/*.md | tail -1`
+2. Create `NNN-short-title.md` using the format above
+3. Add an entry to the index table below
+4. Link from `PLAN.md` if it affects the project roadmap
+
+## Index
+
+| #   | Title                              | Status | Author  | Created    |
+| --- | ---------------------------------- | ------ | ------- | ---------- |
+| 000 | [Origin Plan](000-origin-plan.md)  | active | halcyon | 2026-02-20 |

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -1,0 +1,51 @@
+# Session Logs
+
+This directory contains session logs from AI-agent development sessions on vbuilder.
+
+## File Naming
+
+```
+YYYY-MM-DD-HHMM.md
+```
+
+Use the session start time in UTC.
+
+## Template
+
+```markdown
+# Session YYYY-MM-DD-HHMM
+
+**Agent:** claude-code | claude-code-action
+**Duration:** ~Xh
+**Plan:** [NNN - Title](../plans/NNN-short-title.md)
+
+## Context
+
+Why this session was started and what it set out to accomplish.
+
+## Work Completed
+
+- Bullet list of concrete changes made
+- Include commit SHAs where applicable (e.g. `abc1234`)
+- Reference files changed
+
+## Status Update
+
+Current state of the relevant plan phase after this session.
+
+## Next Steps
+
+- What the next session should pick up
+- Any blockers or open questions
+
+## Handoff Notes
+
+Anything the next agent (or human) needs to know that isn't captured above.
+```
+
+## Guidelines
+
+- **Be concise.** Session logs are reference material, not narratives.
+- **Link to plans.** Every session should reference the plan it advances.
+- **Include commit SHAs.** Makes it easy to trace what changed and when.
+- **Append-only.** Never edit a past session log. If corrections are needed, add a note in a new session.


### PR DESCRIPTION
## Summary

- Introduce planning infrastructure (`docs/plans/`, `docs/sessions/`) with format guides and templates
- Seed the system with **000 - Origin Plan**: the comprehensive 5-phase roadmap for transforming vbuilder into an AI-maintained MEV block builder
- Add `PLAN.md` root dashboard linking to all planning docs

## What's included

| File | Purpose |
|------|---------|
| `PLAN.md` | Root dashboard with phase status table, priorities, decision framework |
| `docs/plans/README.md` | Plan format guide and index |
| `docs/plans/000-origin-plan.md` | Origin Plan — Foundation, CI/CD, Bot Deployment, Testing Harness, Self-Improvement |
| `docs/sessions/README.md` | Session log format and template for agent work sessions |

## Origin Plan Phases

1. **Foundation** — CLAUDE.md, `.ai/` docs, `.claude/commands/`
2. **CI/CD Upgrade** — claude-code-action, security review workflow, branch protection
3. **Bot Deployment** — Issue-driven workflow, guardrails, safety-critical path protection
4. **Testing Harness** — Compiler loop, builder-playground integration, new integration tests
5. **Self-Improvement** — Session logging, doc evolution, upstream sync

## Open questions for reviewer

The Origin Plan includes 5 open questions that need decisions before implementation proceeds (bot identity, Mergify, sync frequency, CI cost, autonomy scope). See the [Open Questions section](docs/plans/000-origin-plan.md#open-questions).

## Test plan

- [x] All 4 files render correctly as GitHub markdown
- [x] All internal links resolve (verified)
- [x] Purely additive — no existing files modified
- [ ] Reviewer evaluates Origin Plan phases and open questions

🤖 Generated with [Claude Code](https://claude.com/claude-code)