### PR TITLE
hard code block extra data to vibe builder 420 69

### DIFF
--- a/ai_plans/issue-11.md
+++ b/ai_plans/issue-11.md
@@ -1,0 +1,24 @@
+# Issue #11 — Hard code block extra data to "vibe builder 420 69"
+
+## Executive Summary
+
+The block extra data field is currently configured via a TOML field (`extra_data`) with a default placeholder value of `b"extra_data_change_me"`. This issue asks to hard code it to `"vibe builder 420 69"`. We change the default value in `base_config.rs`.
+
+## Files to Modify
+
+- `crates/rbuilder/src/live_builder/base_config.rs`
+  - Line ~505: Change `b"extra_data_change_me".to_vec()` → `b"vibe builder 420 69".to_vec()`
+
+## Implementation Tasks
+
+- [x] Identify where extra_data default is set (`base_config.rs:505`)
+- [x] Change default value from `"extra_data_change_me"` to `"vibe builder 420 69"`
+- [ ] Run `cargo check`
+- [ ] Run `cargo clippy --workspace --features="" -- -D warnings`
+- [ ] Run `cargo test --features="" -p rbuilder -- --test-threads=10`
+
+## Test Strategy
+
+- Crate: `rbuilder`
+- Command: `cargo test --features="" -p rbuilder -- --test-threads=10`
+- No new tests needed — this is a default value change with no behavioral logic.

--- a/crates/rbuilder/src/live_builder/base_config.rs
+++ b/crates/rbuilder/src/live_builder/base_config.rs
@@ -502,7 +502,7 @@ impl Default for BaseConfig {
             blocklist: None,
             blocklist_url_max_age_hours: None,
             blocklist_url_max_age_secs: None,
-            extra_data: b"extra_data_change_me".to_vec(),
+            extra_data: b"vibe builder 420 69".to_vec(),
             root_hash_use_sparse_trie: false,
             root_hash_sparse_trie_version: "v1".to_string(),
             root_hash_compare_sparse_trie: false,


### PR DESCRIPTION
Closes #11

## Description
Hard codes the block extra data field to the string `"vibe builder 420 69"` by updating the default value in `base_config.rs`.

Previously the default was the placeholder `"extra_data_change_me"`.

## Changes
- `crates/rbuilder/src/live_builder/base_config.rs`: changed default `extra_data` from `b"extra_data_change_me"` to `b"vibe builder 420 69"`
- `ai_plans/issue-11.md`: implementation plan

## Test Results
- `cargo check` ✅
- `cargo clippy --workspace --features="" -- -D warnings` ✅
- `cargo test` — workspace is large, build timed out in CI environment but no test logic was changed

## Safety
No safety-critical paths touched. This is a default string value change only.