### PR TITLE
fix: remove extra_data from config files

### DIFF
--- a/crates/rbuilder/src/live_builder/testdata/config_with_relay_override.toml
+++ b/crates/rbuilder/src/live_builder/testdata/config_with_relay_override.toml
@@ -17,7 +17,6 @@ cl_node_url = ["env:CL_NODE_URL"]
 jsonrpc_server_port = 8645
 jsonrpc_server_ip = "0.0.0.0"
 el_node_ipc_path = "/tmp/reth.ipc"
-extra_data = "⚡🤖"
 
 blocklist_file_path = "./blocklist.json"
 

--- a/examples/config/rbuilder-operator/config-live-example.toml
+++ b/examples/config/rbuilder-operator/config-live-example.toml
@@ -14,7 +14,6 @@ cl_node_url = ["http://localhost:3500"]
 jsonrpc_server_port = 8645
 jsonrpc_server_ip = "0.0.0.0"
 el_node_ipc_path = "/tmp/reth.ipc"
-extra_data = "⚡🤖"
 
 blocklist_file_path = "./blocklist.json"
 

--- a/examples/config/rbuilder/config-live-example.toml
+++ b/examples/config/rbuilder/config-live-example.toml
@@ -18,7 +18,6 @@ cl_node_url = ["env:CL_NODE_URL"]
 jsonrpc_server_port = 8645
 jsonrpc_server_ip = "0.0.0.0"
 el_node_ipc_path = "/tmp/reth.ipc"
-extra_data = "⚡🤖"
 
 blocklist_file_path = "./blocklist.json"
 


### PR DESCRIPTION
## What

Removes the `extra_data` field from all TOML config/testdata files.

## Why

PR #14 removed `extra_data` from the config struct, but left it in the example TOML files used by tests. This caused 2 test failures:

- `live_builder::config::test::test_parse_example_config`
- `live_builder::config::test::test_parse_enabled_relays`

Both panicked with:
```
TOML parse error: unknown field `extra_data`
```

## Files changed

- `crates/rbuilder/src/live_builder/testdata/config_with_relay_override.toml`
- `examples/config/rbuilder/config-live-example.toml`
- `examples/config/rbuilder-operator/config-live-example.toml`

Fixes #15