### PR TITLE
chore: bump reth to v1.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,61 +70,61 @@ codegen-units = 1
 incremental = false
 
 [workspace.dependencies]
-reth = { git = "https://github.com/paradigmxyz/reth", rev = "27a8c0f5a6dfb27dea84c5751776ecabdd069646" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "27a8c0f5a6dfb27dea84c5751776ecabdd069646" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "27a8c0f5a6dfb27dea84c5751776ecabdd069646" }
-reth-db-common = { git = "https://github.com/paradigmxyz/reth", rev = "27a8c0f5a6dfb27dea84c5751776ecabdd069646" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "27a8c0f5a6dfb27dea84c5751776ecabdd069646" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "27a8c0f5a6dfb27dea84c5751776ecabdd069646" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "27a8c0f5a6dfb27dea84c5751776ecabdd069646" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "27a8c0f5a6dfb27dea84c5751776ecabdd069646" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "27a8c0f5a6dfb27dea84c5751776ecabdd069646" }
-reth-trie-parallel = { git = "https://github.com/paradigmxyz/reth", rev = "27a8c0f5a6dfb27dea84c5751776ecabdd069646" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "27a8c0f5a6dfb27dea84c5751776ecabdd069646" }
-reth-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "27a8c0f5a6dfb27dea84c5751776ecabdd069646" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "27a8c0f5a6dfb27dea84c5751776ecabdd069646" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "27a8c0f5a6dfb27dea84c5751776ecabdd069646" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "27a8c0f5a6dfb27dea84c5751776ecabdd069646", features = [
+reth = { git = "https://github.com/paradigmxyz/reth", rev = "564ffa586845fa4a8bb066f0c7b015ff36b26c08" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "564ffa586845fa4a8bb066f0c7b015ff36b26c08" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "564ffa586845fa4a8bb066f0c7b015ff36b26c08" }
+reth-db-common = { git = "https://github.com/paradigmxyz/reth", rev = "564ffa586845fa4a8bb066f0c7b015ff36b26c08" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "564ffa586845fa4a8bb066f0c7b015ff36b26c08" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "564ffa586845fa4a8bb066f0c7b015ff36b26c08" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "564ffa586845fa4a8bb066f0c7b015ff36b26c08" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "564ffa586845fa4a8bb066f0c7b015ff36b26c08" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "564ffa586845fa4a8bb066f0c7b015ff36b26c08" }
+reth-trie-parallel = { git = "https://github.com/paradigmxyz/reth", rev = "564ffa586845fa4a8bb066f0c7b015ff36b26c08" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "564ffa586845fa4a8bb066f0c7b015ff36b26c08" }
+reth-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "564ffa586845fa4a8bb066f0c7b015ff36b26c08" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "564ffa586845fa4a8bb066f0c7b015ff36b26c08" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "564ffa586845fa4a8bb066f0c7b015ff36b26c08" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "564ffa586845fa4a8bb066f0c7b015ff36b26c08", features = [
     "test-utils",
 ] }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "27a8c0f5a6dfb27dea84c5751776ecabdd069646" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "27a8c0f5a6dfb27dea84c5751776ecabdd069646" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "27a8c0f5a6dfb27dea84c5751776ecabdd069646" }
-reth-execution-errors = { git = "https://github.com/paradigmxyz/reth", rev = "27a8c0f5a6dfb27dea84c5751776ecabdd069646" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "27a8c0f5a6dfb27dea84c5751776ecabdd069646" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "27a8c0f5a6dfb27dea84c5751776ecabdd069646" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "564ffa586845fa4a8bb066f0c7b015ff36b26c08" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "564ffa586845fa4a8bb066f0c7b015ff36b26c08" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "564ffa586845fa4a8bb066f0c7b015ff36b26c08" }
+reth-execution-errors = { git = "https://github.com/paradigmxyz/reth", rev = "564ffa586845fa4a8bb066f0c7b015ff36b26c08" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "564ffa586845fa4a8bb066f0c7b015ff36b26c08" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "564ffa586845fa4a8bb066f0c7b015ff36b26c08" }
 
-# compatible with reth 27a8c0f5a6dfb27dea84c5751776ecabdd069646 dependencies
-revm = { version = "31.0.2", features = [
+# compatible with reth 564ffa586845fa4a8bb066f0c7b015ff36b26c08 (v1.11.0) dependencies
+revm = { version = "34.0.0", features = [
     "std",
     "secp256k1",
     "optional_balance_check",
 ], default-features = false }
-revm-inspectors = { version = "0.32.0", default-features = false }
+revm-inspectors = { version = "0.34.2", default-features = false }
 
 ethereum_ssz_derive = "0.9.0"
 ethereum_ssz = "0.9.0"
 
-alloy-primitives = { version = "1.4.1", default-features = false, features = [
+alloy-primitives = { version = "1.5.6", default-features = false, features = [
     "getrandom",
 ] }
-alloy-rlp = "0.3.10"
+alloy-rlp = "0.3.13"
 alloy-chains = "0.2.5"
-alloy-trie = { version = "0.8.1", default-features = false }
-alloy-evm = { version = "0.23.3", default-features = false }
-alloy-provider = { version = "1.0.41", features = ["ipc", "pubsub", "ws"] }
-alloy-eips = { version = "1.0.41" }
-alloy-rpc-types = { version = "1.0.41" }
-alloy-json-rpc = { version = "1.0.41" }
-alloy-network = { version = "1.0.41" }
-alloy-network-primitives = { version = "1.0.41" }
-alloy-node-bindings = { version = "1.0.41" }
-alloy-consensus = { version = "1.0.41", features = ["kzg"] }
-alloy-rpc-types-beacon = { version = "1.0.41", features = ["ssz"] }
-alloy-rpc-types-engine = { version = "1.0.41", features = ["ssz"] }
-alloy-rpc-types-eth = { version = "1.0.41" }
-alloy-signer = { version = "1.0.41" }
-alloy-signer-local = { version = "1.0.41" }
+alloy-trie = { version = "0.9.4", default-features = false }
+alloy-evm = { version = "0.27.2", default-features = false }
+alloy-provider = { version = "1.6.3", features = ["ipc", "pubsub", "ws"] }
+alloy-eips = { version = "1.6.3" }
+alloy-rpc-types = { version = "1.6.3" }
+alloy-json-rpc = { version = "1.6.3" }
+alloy-network = { version = "1.6.3" }
+alloy-network-primitives = { version = "1.6.3" }
+alloy-node-bindings = { version = "1.6.3" }
+alloy-consensus = { version = "1.6.3", features = ["kzg"] }
+alloy-rpc-types-beacon = { version = "1.6.3", features = ["ssz"] }
+alloy-rpc-types-engine = { version = "1.6.3", features = ["ssz"] }
+alloy-rpc-types-eth = { version = "1.6.3" }
+alloy-signer = { version = "1.6.3" }
+alloy-signer-local = { version = "1.6.3" }
 
 # Version required by ethereum-consensus beacon-api-client
 mev-share-sse = { git = "https://github.com/paradigmxyz/mev-share-rs", rev = "9eb2b0138ab3202b9eb3af4b19c7b3bf40b0faa8", default-features = false }

--- a/crates/eth-sparse-mpt/Cargo.toml
+++ b/crates/eth-sparse-mpt/Cargo.toml
@@ -17,7 +17,7 @@ rustc-hash = "2.0.0"
 rayon = "1.10.0"
 smallvec = "1.13.2"
 alloy-trie.workspace = true
-nybbles = { version = "0.3.3", features = ["serde"] }
+nybbles = { version = "0.4", features = ["serde"] }
 
 tracing.workspace = true
 

--- a/crates/eth-sparse-mpt/src/utils.rs
+++ b/crates/eth-sparse-mpt/src/utils.rs
@@ -28,26 +28,27 @@ pub fn rlp_pointer(rlp_encode: Bytes) -> Bytes {
     }
 }
 
+// nybbles 0.4: Nibbles is Copy and uses a packed U256 representation.
+// extend() takes &Nibbles; from_nibbles_unchecked() takes individual nibble bytes (0-15 each).
+
 pub fn concat_path(p1: &Nibbles, p2: &[u8]) -> Nibbles {
-    let mut result = Nibbles::with_capacity(p1.len() + p2.len());
-    result.extend_from_slice_unchecked(p1);
-    result.extend_from_slice_unchecked(p2);
+    let mut result = *p1;
+    result.extend(&Nibbles::from_nibbles_unchecked(p2));
     result
 }
 
 pub fn strip_first_nibble_mut(p: &mut Nibbles) -> u8 {
-    let nibble = p[0];
-    let vec = p.as_mut_vec_unchecked();
-    vec.remove(0);
+    let nibble = p.get_unchecked(0);
+    *p = p.slice_unchecked(1, p.len());
     nibble
 }
 
 #[inline]
 pub fn extract_prefix_and_suffix(p1: &Nibbles, p2: &Nibbles) -> (Nibbles, Nibbles, Nibbles) {
     let prefix_len = p1.common_prefix_length(p2);
-    let prefix = Nibbles::from_nibbles_unchecked(&p1[..prefix_len]);
-    let suffix1 = Nibbles::from_nibbles_unchecked(&p1[prefix_len..]);
-    let suffix2 = Nibbles::from_nibbles_unchecked(&p2[prefix_len..]);
+    let prefix = p1.slice_unchecked(0, prefix_len);
+    let suffix1 = p1.slice_unchecked(prefix_len, p1.len());
+    let suffix2 = p2.slice_unchecked(prefix_len, p2.len());
 
     (prefix, suffix1, suffix2)
 }
@@ -135,17 +136,4 @@ fn mismatch_chunks<const N: usize>(xs: &[u8], ys: &[u8]) -> usize {
     off + std::iter::zip(&xs[off..], &ys[off..])
         .take_while(|(x, y)| x == y)
         .count()
-}
-
-// rbuilder uses nybbles v3.3.0 and reth_trie uses nybbles v4.3.0. This is a temporary fix to convert between the two.
-// We can remove the below methods once rbuilder has been upgraded to nybbles v4.3.0.
-// nybbles v4.3.0 has a breaking change (byte array with 1 byte per nybble vs U256 packed data + length) in the API which breaks a lot of parts of the eth sparse trie code.
-#[inline]
-pub fn convert_reth_nybbles_to_nibbles(n: reth_trie::Nibbles) -> Nibbles {
-    Nibbles::from_nibbles(n.to_vec())
-}
-
-#[inline]
-pub fn convert_nibbles_to_reth_nybbles(n: Nibbles) -> reth_trie::Nibbles {
-    reth_trie::Nibbles::from_nibbles(n.as_slice())
 }

--- a/crates/eth-sparse-mpt/src/v1/reth_sparse_trie/trie_fetcher/mod.rs
+++ b/crates/eth-sparse-mpt/src/v1/reth_sparse_trie/trie_fetcher/mod.rs
@@ -1,6 +1,6 @@
 use std::time::Instant;
 
-use crate::utils::{convert_reth_nybbles_to_nibbles, hash_map_with_capacity, HashMap, HashSet};
+use crate::utils::{hash_map_with_capacity, HashMap, HashSet};
 use alloy_primitives::map::HashSet as AlloyHashSet;
 use tracing::trace;
 
@@ -106,7 +106,9 @@ where
 }
 
 fn pad_path(mut path: Nibbles) -> B256 {
-    path.as_mut_vec_unchecked().resize(64, 0);
+    while path.len() < 64 {
+        path.push_unchecked(0);
+    }
     let mut res = B256::default();
     path.pack_to(res.as_mut_slice());
     res
@@ -190,11 +192,12 @@ fn convert_reth_multiproof(
     reth_proof: RethMultiProof,
     all_requested_accounts: &HashSet<B256>,
 ) -> MultiProof {
+    // nybbles 0.4: nybbles::Nibbles == reth_trie::Nibbles — no conversion needed.
     let mut account_subtree = Vec::with_capacity(reth_proof.account_subtree.len());
     for (k, v) in reth_proof.account_subtree.into_inner() {
-        account_subtree.push((convert_reth_nybbles_to_nibbles(k), v));
+        account_subtree.push((k, v));
     }
-    account_subtree.sort_by_key(|a| a.0.clone());
+    account_subtree.sort_by_key(|a| a.0);
     let mut storages = hash_map_with_capacity(reth_proof.storages.len());
     for (k, reth_storage_proof) in reth_proof.storages {
         if !all_requested_accounts.contains(&k) {
@@ -206,9 +209,9 @@ fn convert_reth_multiproof(
         let mut subtree = Vec::with_capacity(reth_storage_proof.subtree.len());
 
         for (k, v) in reth_storage_proof.subtree.into_inner() {
-            subtree.push((convert_reth_nybbles_to_nibbles(k), v));
+            subtree.push((k, v));
         }
-        subtree.sort_by_key(|a| a.0.clone());
+        subtree.sort_by_key(|a| a.0);
         let v = StorageMultiProof { subtree };
         storages.insert(k, v);
     }

--- a/crates/eth-sparse-mpt/src/v1/sparse_mpt/diff_trie/mod.rs
+++ b/crates/eth-sparse-mpt/src/v1/sparse_mpt/diff_trie/mod.rs
@@ -65,7 +65,7 @@ pub struct NodeCursor {
 
 impl NodeCursor {
     pub fn new(key: Nibbles, head: u64) -> Self {
-        let current_path = Nibbles::with_capacity(key.len());
+        let current_path = Nibbles::new();
         Self {
             current_node: head,
             current_path,
@@ -75,9 +75,9 @@ impl NodeCursor {
 
     pub fn step_into_extension(&mut self, ext: &DiffExtensionNode) {
         let len = ext.key().len();
-        self.current_path
-            .extend_from_slice_unchecked(&self.path_left[..len]);
-        self.path_left.as_mut_vec_unchecked().drain(..len);
+        let prefix = self.path_left.slice_unchecked(0, len);
+        self.current_path.extend(&prefix);
+        self.path_left = self.path_left.slice_unchecked(len, self.path_left.len());
         self.current_node = ext.child.ptr();
     }
 
@@ -332,9 +332,10 @@ impl DiffTrie {
                             .other_child_nibble(n)
                             .expect("other child must exist");
                         if branch.get_diff_child(other_child_nibble).is_none() {
-                            let mut other_child_path = c.current_path.clone();
-                            if let Some(l) = other_child_path.as_mut_vec_unchecked().last_mut() {
-                                *l = other_child_nibble;
+                            let mut other_child_path = c.current_path;
+                            if !other_child_path.is_empty() {
+                                other_child_path.pop();
+                                other_child_path.push_unchecked(other_child_nibble);
                             }
                             return Err(DeletionError::NodeNotFound(ErrSparseNodeNotFound {
                                 path: other_child_path,
@@ -428,9 +429,9 @@ impl DiffTrie {
                             DiffTrieNodeKind::Leaf(leaf_below),
                         ) => {
                             // we just replace extension node by merging its path into leaf with child_nibble
-                            let mut new_leaf_key = ext_above.key().clone();
+                            let mut new_leaf_key = *ext_above.key();
                             new_leaf_key.push(*child_nibble);
-                            new_leaf_key.extend_from_slice_unchecked(leaf_below.key());
+                            new_leaf_key.extend(leaf_below.key());
 
                             let mut new_leaf = leaf_below;
                             new_leaf.changed_key = Some(new_leaf_key);
@@ -443,7 +444,7 @@ impl DiffTrie {
                             // we merge two extension nodes into current node with child_nibble
                             let ext_key = ext_above.key_mut();
                             ext_key.push(*child_nibble);
-                            ext_key.extend_from_slice_unchecked(ext_below.key());
+                            ext_key.extend(ext_below.key());
 
                             ext_above.child = ext_below.child.clone();
                         }
@@ -469,10 +470,12 @@ impl DiffTrie {
                             DiffTrieNodeKind::Leaf(mut leaf_below),
                         ) => {
                             // merge missing nibble into the leaf
-                            leaf_below
-                                .key_mut()
-                                .as_mut_vec_unchecked()
-                                .insert(0, *child_nibble);
+                            {
+                                let old = *leaf_below.key();
+                                let k = leaf_below.key_mut();
+                                *k = Nibbles::from_nibbles_unchecked([*child_nibble]);
+                                k.extend(&old);
+                            }
 
                             let new_leaf_ptr = get_new_ptr(&mut self.ptrs);
                             let new_child = DiffTrieNode {
@@ -491,10 +494,12 @@ impl DiffTrie {
                             DiffTrieNodeKind::Extension(mut ext_below),
                         ) => {
                             // merge missing nibble into the extension
-                            ext_below
-                                .key_mut()
-                                .as_mut_vec_unchecked()
-                                .insert(0, *child_nibble);
+                            {
+                                let old = *ext_below.key();
+                                let k = ext_below.key_mut();
+                                *k = Nibbles::from_nibbles_unchecked([*child_nibble]);
+                                k.extend(&old);
+                            }
                             let new_child_ptr = get_new_ptr(&mut self.ptrs);
                             let new_child = DiffTrieNode {
                                 kind: DiffTrieNodeKind::Extension(ext_below),
@@ -563,13 +568,17 @@ impl DiffTrie {
                     .expect("orphaned child existence verif");
                 match &mut child_below.kind {
                     DiffTrieNodeKind::Leaf(leaf) => {
-                        leaf.key_mut()
-                            .as_mut_vec_unchecked()
-                            .insert(0, child_nibble);
+                        let old = *leaf.key();
+                        let k = leaf.key_mut();
+                        *k = Nibbles::from_nibbles_unchecked([child_nibble]);
+                        k.extend(&old);
                         child_below.rlp_pointer = None;
                     }
                     DiffTrieNodeKind::Extension(ext) => {
-                        ext.key_mut().as_mut_vec_unchecked().insert(0, child_nibble);
+                        let old = *ext.key();
+                        let k = ext.key_mut();
+                        *k = Nibbles::from_nibbles_unchecked([child_nibble]);
+                        k.extend(&old);
                         child_below.rlp_pointer = None;
                     }
                     DiffTrieNodeKind::Branch(_) => {

--- a/crates/eth-sparse-mpt/src/v1/sparse_mpt/fixed_trie.rs
+++ b/crates/eth-sparse-mpt/src/v1/sparse_mpt/fixed_trie.rs
@@ -286,8 +286,8 @@ impl FixedTrie {
                             parent_child_idx = None;
 
                             let len = node.key.len();
-                            current_path.extend_from_slice_unchecked(&path_left[..len]);
-                            path_left.as_mut_vec_unchecked().drain(..len);
+                            current_path.extend(&path_left.slice_unchecked(0, len));
+                            path_left = path_left.slice_unchecked(len, path_left.len());
 
                             if path_left.is_empty() {
                                 break;
@@ -455,11 +455,9 @@ impl FixedTrie {
                                         // orphan node is missing
                                         // we stepped into child above so the path is the path of current child and orphan child differs
                                         // only in last nibble
-                                        let mut path = c.current_path.clone();
-                                        path.as_mut_vec_unchecked()
-                                            .last_mut()
-                                            .map(|n| *n = orphan_nibble)
-                                            .unwrap();
+                                        let mut path = c.current_path;
+                                        path.pop();
+                                        path.push_unchecked(orphan_nibble);
                                         missing_nodes.push(path);
                                     }
                                 }

--- a/crates/eth-sparse-mpt/src/v2/fetch.rs
+++ b/crates/eth-sparse-mpt/src/v2/fetch.rs
@@ -1,9 +1,6 @@
 use std::sync::Arc;
 
-use crate::{
-    utils::{convert_nibbles_to_reth_nybbles, convert_reth_nybbles_to_nibbles, HashMap},
-    SparseTrieError,
-};
+use crate::{utils::HashMap, SparseTrieError};
 use alloy_primitives::map::B256Set;
 use parking_lot::Mutex;
 use rayon::prelude::*;
@@ -89,13 +86,10 @@ impl MissingNodesFetcher {
                         .map_err(SparseTrieError::other)?;
                     *fetched_nodes.lock() += requested_proofs.len();
                     for requested_proof in requested_proofs {
-                        let proof_for_node = storge_multiproof.subtree.matching_nodes_sorted(
-                            &convert_nibbles_to_reth_nybbles(requested_proof.clone()),
-                        );
-                        let reth_proof_for_node = proof_for_node
-                            .into_iter()
-                            .map(|(k, v)| (convert_reth_nybbles_to_nibbles(k), v))
-                            .collect();
+                        // nybbles 0.4: Nibbles type unified — no conversion needed.
+                        let proof_for_node =
+                            storge_multiproof.subtree.matching_nodes_sorted(&requested_proof);
+                        let reth_proof_for_node: Vec<_> = proof_for_node.into_iter().collect();
                         let proof_store =
                             shared_cache.account_proof_store_hashed_address(&hashed_address);
                         proof_store
@@ -133,12 +127,9 @@ impl MissingNodesFetcher {
         for requested_node in self.account_proof_requested_nodes.drain(..) {
             let proof_for_node = multiproof
                 .account_subtree
-                .matching_nodes_sorted(&convert_nibbles_to_reth_nybbles(requested_node.clone()));
+                .matching_nodes_sorted(&requested_node);
 
-            let reth_proof_for_node = proof_for_node
-                .into_iter()
-                .map(|(k, v)| (convert_reth_nybbles_to_nibbles(k), v))
-                .collect();
+            let reth_proof_for_node: Vec<_> = proof_for_node.into_iter().collect();
             shared_cache
                 .account_trie
                 .add_proof(requested_node, reth_proof_for_node)
@@ -150,7 +141,9 @@ impl MissingNodesFetcher {
 }
 
 fn pad_path(mut path: Nibbles) -> B256 {
-    path.as_mut_vec_unchecked().resize(64, 0);
+    while path.len() < 64 {
+        path.push_unchecked(0);
+    }
     let mut res = B256::default();
     path.pack_to(res.as_mut_slice());
     res

--- a/crates/eth-sparse-mpt/src/v2/trie/mod.rs
+++ b/crates/eth-sparse-mpt/src/v2/trie/mod.rs
@@ -199,7 +199,7 @@ impl Trie {
         nibbles_key: &Nibbles,
         insert_value: InsertValue<'_>,
     ) -> Result<Option<Range<usize>>, NodeNotFound> {
-        let ins_key = nibbles_key.as_slice();
+        let ins_key = nibbles_key.to_vec();
 
         let mut current_node = 0;
         let mut path_walked = 0;
@@ -377,7 +377,7 @@ impl Trie {
         &mut self,
         nibbles_key: &Nibbles,
     ) -> Result<Range<usize>, DeletionError> {
-        let del_key = nibbles_key.as_slice();
+        let del_key = nibbles_key.to_vec();
 
         let mut current_node = 0;
         let mut path_walked = 0;
@@ -423,9 +423,10 @@ impl Trie {
                                 .unwrap();
                             let orphan_ptr = orphan_ptr.unwrap();
                             if orphan_ptr.is_remote() {
-                                let mut orphan_path = Nibbles::with_capacity(path_walked);
-                                orphan_path
-                                    .extend_from_slice_unchecked(&del_key[..(path_walked - 1)]);
+                                let mut orphan_path = Nibbles::new();
+                                orphan_path.extend(&Nibbles::from_nibbles_unchecked(
+                                    &del_key[..(path_walked - 1)],
+                                ));
                                 orphan_path.push_unchecked(orphan_nibble as u8);
                                 return Err(NodeNotFound(orphan_path).into());
                             }
@@ -875,6 +876,8 @@ impl Trie {
 
         let mut current_node = 0;
         let mut path_walked = 0;
+        // Convert to Vec<u8> for nibble-by-nibble indexing (nybbles 0.4 has no Index impl).
+        let target_key_slice = target_key.to_vec();
 
         loop {
             let node = self
@@ -888,7 +891,7 @@ impl Trie {
 
             self.rlp_encode_node(current_node, &mut buf, proof_store);
             let current_node_path =
-                Nibbles::from_nibbles_unchecked(&target_key.as_slice()[..path_walked]);
+                target_key.slice_unchecked(0, path_walked);
             result.proof.push((current_node_path, buf.clone()));
 
             match node {
@@ -899,7 +902,7 @@ impl Trie {
 
                     let children = *children;
 
-                    let n = target_key[path_walked];
+                    let n = target_key_slice[path_walked];
                     path_walked += 1;
 
                     if let Some(child_ptr) = self.branch_node_children[children][n as usize] {
@@ -915,7 +918,7 @@ impl Trie {
                     let key = key.clone();
                     let next_node = *next_node;
 
-                    if target_key[path_walked..].starts_with(&self.keys[key.clone()]) {
+                    if target_key_slice[path_walked..].starts_with(&self.keys[key.clone()]) {
                         path_walked += key.len();
                         current_node = next_node
                             .as_local()
@@ -926,7 +929,7 @@ impl Trie {
                     break;
                 }
                 DiffTrieNode::Leaf { key, value } => {
-                    if self.keys[key.clone()] == target_key[path_walked..] {
+                    if self.keys[key.clone()] == target_key_slice[path_walked..] {
                         result.value = Some(self.values[value.clone()].to_vec());
                     }
                     break;
@@ -1059,6 +1062,8 @@ impl Trie {
 
         let mut current_node = 0;
         let mut path_walked = 0;
+        // Convert to Vec<u8> for nibble indexing (nybbles 0.4 has no Index impl on Nibbles).
+        let path = path.to_vec();
 
         let mut parent_ptr = None;
         let mut parent_nibble = 0;


### PR DESCRIPTION
## What

Bumps reth git dependency from rev `27a8c0f` to `564ffa5` (v1.11.0, released 2026-02-16).

## Dependency changes

| Dep | Old | New |
|-----|-----|-----|
| reth (all) | rev 27a8c0f | rev 564ffa5 (v1.11.0) |
| alloy (all) | 1.0.41 | 1.6.3 |
| revm | 31.0.2 | 34.0.0 |
| revm-inspectors | 0.32.0 | 0.34.2 |
| alloy-primitives | 1.4.1 | 1.5.6 |
| alloy-rlp | 0.3.10 | 0.3.13 |
| alloy-trie | 0.8.1 | 0.9.4 |
| alloy-evm | 0.23.3 | 0.27.2 |

## Status

🚧 Draft — waiting for CI to identify any compilation errors from API changes between versions. Will fix and update.

Closes #18