### PR TITLE
add lobster emoji to extra data

### DIFF
--- a/crates/rbuilder/src/live_builder/base_config.rs
+++ b/crates/rbuilder/src/live_builder/base_config.rs
@@ -55,7 +55,7 @@ use super::{
 };
 
 /// Hard-coded block extra data included in every block built by vbuilder.
-pub const EXTRA_DATA: &[u8] = b"vibe builder 420 69";
+pub const EXTRA_DATA: &[u8] = "vibe builder 420 69 🦞".as_bytes();
 
 /// Base config to be used by all builders.
 /// It allows us to create a base LiveBuilder with no algorithms or custom bidding.

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -655,13 +655,11 @@ where
                 PartialBlockExecutionTracerType,
             >(config, input, partial_block_execution_tracer)
         }
-        Sorting::TxHash => {
-            crate::building::builders::ordering_builder::backtest_simulate_block::<
-                P,
-                OrderTxHashPriority<ProfitInfoGetterType>,
-                PartialBlockExecutionTracerType,
-            >(config, input, partial_block_execution_tracer)
-        }
+        Sorting::TxHash => crate::building::builders::ordering_builder::backtest_simulate_block::<
+            P,
+            OrderTxHashPriority<ProfitInfoGetterType>,
+            PartialBlockExecutionTracerType,
+        >(config, input, partial_block_execution_tracer),
         Sorting::ReverseTxHash => {
             crate::building::builders::ordering_builder::backtest_simulate_block::<
                 P,


### PR DESCRIPTION
Closes #26

## Description
Adds a lobster emoji (🦞) to the `EXTRA_DATA` constant in `base_config.rs`, changing it from `b"vibe builder 420 69"` to `"vibe builder 420 69 🦞".as_bytes()`.

The total byte length is 24 bytes (the lobster emoji is 4 bytes in UTF-8), well within Ethereum's 32-byte extra data limit.

## Test Results
- cargo check: ✅ pass
- cargo clippy --workspace -- -D warnings: ✅ pass
- cargo test --workspace: compilation passed, 133/134 tests passed. The single failure (`test_fetcher_retrieves_transactions`) is a pre-existing environment issue (PermissionDenied when spawning a subprocess), unrelated to this change.

## Safety
No safety-critical paths affected. This is a cosmetic change to a string constant.